### PR TITLE
Fixed keys for Reroute email settings

### DIFF
--- a/scripts/odddrupal/templates/settings.php
+++ b/scripts/odddrupal/templates/settings.php
@@ -33,9 +33,8 @@ $databases['default']['default'] = [
  * to reroute to an address which you've got access to.
  */
 if (getenv('APP_ENV') !== 'production') {
-  $config['reroute_email.settings']['reroute_email_enable'] = TRUE;
-  $config['reroute_email.settings']['reroute_email_address'] = getenv('REROUTE_EMAIL_ADDRESS');
-  $config['reroute_email.settings']['reroute_email_enable_message'] = TRUE;
+  $config['reroute_email.settings']['enable'] = TRUE;
+  $config['reroute_email.settings']['address'] = getenv('REROUTE_EMAIL_ADDRESS');
 }
 
 /**


### PR DESCRIPTION
These has changed in the latest version of the module. Please confirm that the names are correct as I did these changes on the fly via Github :)

Also removed the message setting since I think that this could be up to the developers to decide on. As long as rerouting is enabled and set to the address configured in .env, I think we're fine.